### PR TITLE
Fix result modal working only on first table page

### DIFF
--- a/ndscheduler/static/index.html
+++ b/ndscheduler/static/index.html
@@ -82,7 +82,12 @@
                             <option value="600">10 minutes</option>
                             <option value="3600">1 hour</option>
                             <option value="43200">12 hours</option>
-                            <option value="86400">24 hours</option>
+                            <option value="86400">1 day</option>
+                            <option value="172800">2 days</option>
+                            <option value="604800">1 week</option>
+                            <option value="2592000">1 month</option>
+                            <option value="15552000">6 months</option>
+                            <option value="31557600">1 year</option>
                         </select>
                     </div>
                     <div class="form-group">

--- a/ndscheduler/static/js/views/executions/table-view.js
+++ b/ndscheduler/static/js/views/executions/table-view.js
@@ -58,7 +58,7 @@ define(['utils',
         ]
       });
 
-      $('#executions-table tbody').on('click', '[data-action=show-result]', function(e){
+      $('#executions-table tbody').on('click', '[data-action=show-result]', function(e) {
           e.preventDefault();
           $('#result-box').text(decodeURI($(this).data('content')));
           $('#execution-result-modal').modal();

--- a/ndscheduler/static/js/views/executions/table-view.js
+++ b/ndscheduler/static/js/views/executions/table-view.js
@@ -57,6 +57,12 @@ define(['utils',
           { "orderable": false, "className": "table-result-column", "targets": 5 }
         ]
       });
+
+      $('#executions-table tbody').on('click', '[data-action=show-result]', function(e){
+          e.preventDefault();
+          $('#result-box').text(decodeURI($(this).data('content')));
+          $('#execution-result-modal').modal();
+      });
     },
 
     /**
@@ -100,21 +106,12 @@ define(['utils',
       if (data.length) {
         this.table.fnClearTable();
         this.table.fnAddData(data);
-
-        var buttons = $('[data-action=show-result]');
-        _.each(buttons, function(btn) {
-          $(btn).on('click', _.bind(function(e) {
-            e.preventDefault();
-            $('#result-box').text(decodeURI($(btn).data('content')));
-            $('#execution-result-modal').modal();
-          }, this));
-
-          // If there's a query parameter result, we'll display the result.
-          if (!_.isUndefined(utils.getParameterByName('result'))) {
-            $('#result-box').text(executions[0].get('result'));
-            $('#execution-result-modal').modal();
-          }
-        });
+        
+        // If there's a query parameter result, we'll display the result.
+        if (!_.isUndefined(utils.getParameterByName('result'))) {
+          $('#result-box').text(executions[0].get('result'));
+          $('#execution-result-modal').modal();
+        }
       }
 
       utils.stopSpinner(this.spinner);


### PR DESCRIPTION
When using pagination, dataTables adds and removes \<tr\>'s from the DOM on every page change which causes new buttons to not have any 'click' callbacks.

The fix is to move the 'click' callback from each button to 'tbody' and use a selector instead.