### PR TITLE
implement basic authentication

### DIFF
--- a/ndscheduler/default_settings.py
+++ b/ndscheduler/default_settings.py
@@ -92,5 +92,12 @@ SCHEDULER_CLASS = 'ndscheduler.core.scheduler.base.SingletonScheduler'
 logging.getLogger().setLevel(logging.INFO)
 
 
+# To enable basic authentication, define the 'user' and 'pass'
+BASIC_AUTH_CONFIG = {
+    'user': '',
+    'pass': '',
+    'realm': 'Next Scheduler'
+}
+
 # Packages that contains job classes, e.g., simple_scheduler.jobs
 JOB_CLASS_PACKAGES = []

--- a/ndscheduler/default_settings.py
+++ b/ndscheduler/default_settings.py
@@ -96,7 +96,7 @@ logging.getLogger().setLevel(logging.INFO)
 BASIC_AUTH_CONFIG = {
     'user': '',
     'pass': '',
-    'realm': 'Next Scheduler'
+    'realm': 'Nextdoor Scheduler'
 }
 
 # Packages that contains job classes, e.g., simple_scheduler.jobs


### PR DESCRIPTION
Implement a basic authentication which is turned off by default.

To enable basic authentication, define the 'user' and 'pass' in the settings:
```
BASIC_AUTH_CONFIG = {
    'user': '',
    'pass': '',
    'realm': 'Nextdoor Scheduler'
}
```