### PR TITLE
Support customized tornado_settings (issue #22)

### DIFF
--- a/ndscheduler/server/server.py
+++ b/ndscheduler/server/server.py
@@ -27,8 +27,18 @@ class SchedulerServer:
 
     singleton = None
 
-    def __init__(self, scheduler_instance):
-        # Start scheduler
+    def __init__(self, scheduler_instance, custom_tornado_settings=None):
+        """
+        Start scheduler
+
+        Pass:
+          scheduler_instance - instance of the `SchedulerManager` class
+          custom_tornado_settings - optional dictionary of settings, to
+                                    be merged if present with the defaults
+                                    set below, adding to and/or replacing
+                                    the settings in `self.tornado_settings`
+        """
+
         self.scheduler_manager = scheduler_instance
 
         self.tornado_settings = dict(
@@ -37,6 +47,8 @@ class SchedulerServer:
             template_path=settings.TEMPLATE_DIR_PATH,
             scheduler_manager=self.scheduler_manager
         )
+        if custom_tornado_settings is not None:
+            self.tornado_settings.update(custom_tornado_settings)
 
         # Setup server
         URLS = [


### PR DESCRIPTION
I didn't find a regression test suite, so my testing consists of applying the change to our own development environment (along with some temporary debug logging code, not included in the patch), and running it with a modification to our own class derived from `SchedulerServer` to invoke the base class constructor with a dictionary of our own override for one of the `tornado` settings passed as the new `custom_tornado_settings` argument. The patch appears to behave as expected, without breaking anything. If you have any private test suites not included with the repository, please run them. 