### PR TITLE
Newer versions of python dependencies

### DIFF
--- a/ndscheduler/__init__.py
+++ b/ndscheduler/__init__.py
@@ -80,11 +80,11 @@ class Settings(object):
                 error = ImportError(
                     'Could not import settings "%s" (Is it on sys.path?): %s' %
                     (settings_module_path, e))
-                logger.warn(error)
+                logger.warning(error)
         except KeyError:
             # NOTE: This is arguably an EnvironmentError, but that causes
             # problems with Python's interactive help.
-            logger.warn(
+            logger.warning(
                 ('Environment variable %s is undefined. '
                  'Use default settings for now.') % ENVIRONMENT_VARIABLE)
 

--- a/ndscheduler/core/datastore/providers/base_test.py
+++ b/ndscheduler/core/datastore/providers/base_test.py
@@ -5,7 +5,7 @@ import unittest
 
 from ndscheduler import constants
 from ndscheduler.core.datastore.providers import base
-
+from apscheduler.schedulers.blocking import BlockingScheduler
 
 class SimpleDatastore(base.DatastoreBase):
 
@@ -20,7 +20,9 @@ class SimpleDatastore(base.DatastoreBase):
 class DatastoreBaseTest(unittest.TestCase):
 
     def setUp(self):
+        fake_scheduler = BlockingScheduler()
         self.store = SimpleDatastore.get_instance()
+        self.store.start(fake_scheduler, None)
 
     def test_add_execution_get_execution(self):
         eid = '12345'

--- a/ndscheduler/core/datastore/providers/base_test.py
+++ b/ndscheduler/core/datastore/providers/base_test.py
@@ -7,6 +7,7 @@ from ndscheduler import constants
 from ndscheduler.core.datastore.providers import base
 from apscheduler.schedulers.blocking import BlockingScheduler
 
+
 class SimpleDatastore(base.DatastoreBase):
 
     @classmethod

--- a/ndscheduler/core/scheduler_manager_test.py
+++ b/ndscheduler/core/scheduler_manager_test.py
@@ -81,7 +81,7 @@ class SchedulerManagerTest(tornado.testing.AsyncTestCase):
         job_class_string = 'hello.world1234'
         args = ['5', '6', '7']
         name = 'hello world 3'
-        month = '*/12'
+        month = '*/6'
 
         # non-blocking operation
         self.scheduler.modify_job(job_id, name=name, job_class_string=job_class_string,

--- a/ndscheduler/core/scheduler_manager_test.py
+++ b/ndscheduler/core/scheduler_manager_test.py
@@ -45,21 +45,21 @@ class SchedulerManagerTest(tornado.testing.AsyncTestCase):
         self.assertEqual(utils.get_job_kwargs(job), {'languages': 'en-us'})
 
         # Year
-        self.assertEquals(str(job.trigger.fields[0]), '*')
+        self.assertEqual(str(job.trigger.fields[0]), '*')
         # Month
-        self.assertEquals(str(job.trigger.fields[1]), month)
+        self.assertEqual(str(job.trigger.fields[1]), month)
         # day of month
-        self.assertEquals(str(job.trigger.fields[2]), day)
+        self.assertEqual(str(job.trigger.fields[2]), day)
         # week
-        self.assertEquals(str(job.trigger.fields[3]), '*')
+        self.assertEqual(str(job.trigger.fields[3]), '*')
         # day of week
-        self.assertEquals(str(job.trigger.fields[4]), day_of_week)
+        self.assertEqual(str(job.trigger.fields[4]), day_of_week)
         # hour
-        self.assertEquals(str(job.trigger.fields[5]), hour)
+        self.assertEqual(str(job.trigger.fields[5]), hour)
         # minute
-        self.assertEquals(str(job.trigger.fields[6]), minute)
+        self.assertEqual(str(job.trigger.fields[6]), minute)
         # second
-        self.assertEquals(str(job.trigger.fields[7]), '0')
+        self.assertEqual(str(job.trigger.fields[7]), '0')
 
     @tornado.testing.gen_test
     def test_add_job_modify_job(self):
@@ -89,9 +89,9 @@ class SchedulerManagerTest(tornado.testing.AsyncTestCase):
 
         # blocking operation
         job = self.scheduler.get_job(job_id)
-        self.assertEquals(job.name, name)
+        self.assertEqual(job.name, name)
 
         arguments = [job_class_string, job_id]
         arguments += args
-        self.assertEquals(list(job.args), arguments)
-        self.assertEquals(str(job.trigger.fields[1]), month)
+        self.assertEqual(list(job.args), arguments)
+        self.assertEqual(str(job.trigger.fields[1]), month)

--- a/ndscheduler/server/handlers/executions_test.py
+++ b/ndscheduler/server/handlers/executions_test.py
@@ -57,7 +57,7 @@ class ExecutionsTest(tornado.testing.AsyncHTTPTestCase):
         return_info = json.loads(response.body.decode())
         self.assertEqual(return_info['execution_id'], execution1['eid'])
         self.assertEqual(return_info['state'],
-                          constants.EXECUTION_STATUS_DICT[execution1['state']])
+                         constants.EXECUTION_STATUS_DICT[execution1['state']])
 
     def test_get_execution1(self):
         datastore = self.scheduler.get_datastore()

--- a/ndscheduler/server/handlers/executions_test.py
+++ b/ndscheduler/server/handlers/executions_test.py
@@ -55,8 +55,8 @@ class ExecutionsTest(tornado.testing.AsyncHTTPTestCase):
         datastore.add_execution(execution1['eid'], execution1['job_id'], execution1['state'])
         response = self.fetch(self.EXECUTIONS_URL + '/%s?sync=true' % execution1['eid'])
         return_info = json.loads(response.body.decode())
-        self.assertEquals(return_info['execution_id'], execution1['eid'])
-        self.assertEquals(return_info['state'],
+        self.assertEqual(return_info['execution_id'], execution1['eid'])
+        self.assertEqual(return_info['state'],
                           constants.EXECUTION_STATUS_DICT[execution1['state']])
 
     def test_get_execution1(self):
@@ -73,4 +73,4 @@ class ExecutionsTest(tornado.testing.AsyncHTTPTestCase):
         response = self.fetch(self.EXECUTIONS_URL + '?time_range_end=%s' % (
             two_minutes_later.isoformat()))
         return_info = json.loads(response.body.decode())
-        self.assertEquals(return_info['executions'][0]['execution_id'], execution1['eid'])
+        self.assertEqual(return_info['executions'][0]['execution_id'], execution1['eid'])

--- a/ndscheduler/server/handlers/jobs_test.py
+++ b/ndscheduler/server/handlers/jobs_test.py
@@ -72,7 +72,7 @@ class JobsTest(tornado.testing.AsyncHTTPTestCase):
                               body=json.dumps(data))
         return_info = json.loads(response.body.decode())
         self.assertTrue('job_id' in return_info)
-        self.assertEquals(len(return_info['job_id']), 32)
+        self.assertEqual(len(return_info['job_id']), 32)
         job = self.scheduler.get_job(return_info['job_id'])
         self.assertEqual(job.name, data['name'])
 
@@ -83,14 +83,14 @@ class JobsTest(tornado.testing.AsyncHTTPTestCase):
             'name': 'hello world job'}
         response = self.fetch(self.JOBS_URL, method='POST', headers=headers,
                               body=json.dumps(data))
-        self.assertEquals(response.code, 400)
+        self.assertEqual(response.code, 400)
 
         data = {
             'job_class_string': 'hello.world',
             'minute': '*/5'}
         response = self.fetch(self.JOBS_URL, method='POST', headers=headers,
                               body=json.dumps(data))
-        self.assertEquals(response.code, 400)
+        self.assertEqual(response.code, 400)
 
     def test_pause_resume_job(self):
         headers = {'Content-Type': 'application/json; charset=UTF-8'}
@@ -102,14 +102,14 @@ class JobsTest(tornado.testing.AsyncHTTPTestCase):
                               body=json.dumps(data))
         return_info = json.loads(response.body.decode())
         self.assertTrue('job_id' in return_info)
-        self.assertEquals(len(return_info['job_id']), 32)
+        self.assertEqual(len(return_info['job_id']), 32)
 
         response = self.fetch(self.JOBS_URL + '/' + return_info['job_id'],
                               method='PATCH', body='{}')
-        self.assertEquals(response.code, 200)
+        self.assertEqual(response.code, 200)
 
         response = self.fetch(self.JOBS_URL + '/' + return_info['job_id'], method='OPTIONS')
-        self.assertEquals(response.code, 200)
+        self.assertEqual(response.code, 200)
 
     def test_get_jobs(self):
         headers = {'Content-Type': 'application/json; charset=UTF-8'}
@@ -121,15 +121,15 @@ class JobsTest(tornado.testing.AsyncHTTPTestCase):
                               body=json.dumps(data))
         return_info = json.loads(response.body.decode())
         self.assertTrue('job_id' in return_info)
-        self.assertEquals(len(return_info['job_id']), 32)
+        self.assertEqual(len(return_info['job_id']), 32)
 
         response = self.fetch(self.JOBS_URL + '?sync=true')
         return_info = json.loads(response.body.decode())
-        self.assertEquals(len(return_info['jobs']), 1)
+        self.assertEqual(len(return_info['jobs']), 1)
         job = return_info['jobs'][0]
-        self.assertEquals(job['job_class_string'], data['job_class_string'])
-        self.assertEquals(job['name'], data['name'])
-        self.assertEquals(job['minute'], data['minute'])
+        self.assertEqual(job['job_class_string'], data['job_class_string'])
+        self.assertEqual(job['name'], data['name'])
+        self.assertEqual(job['minute'], data['minute'])
 
     def test_delete_job(self):
         headers = {'Content-Type': 'application/json; charset=UTF-8'}
@@ -141,15 +141,15 @@ class JobsTest(tornado.testing.AsyncHTTPTestCase):
                               body=json.dumps(data))
         return_info = json.loads(response.body.decode())
         self.assertTrue('job_id' in return_info)
-        self.assertEquals(len(return_info['job_id']), 32)
+        self.assertEqual(len(return_info['job_id']), 32)
 
         response = self.fetch(self.JOBS_URL + '/' + return_info['job_id'] + '?sync=true',
                               method='DELETE')
-        self.assertEquals(response.code, 200)
+        self.assertEqual(response.code, 200)
 
         response = self.fetch(self.JOBS_URL + '?sync=true')
         return_info = json.loads(response.body.decode())
-        self.assertEquals(len(return_info['jobs']), 0)
+        self.assertEqual(len(return_info['jobs']), 0)
 
     def test_modify_job(self):
         headers = {'Content-Type': 'application/json; charset=UTF-8'}
@@ -161,10 +161,10 @@ class JobsTest(tornado.testing.AsyncHTTPTestCase):
                               body=json.dumps(data))
         return_info = json.loads(response.body.decode())
         self.assertTrue('job_id' in return_info)
-        self.assertEquals(len(return_info['job_id']), 32)
+        self.assertEqual(len(return_info['job_id']), 32)
         job = self.scheduler.get_job(return_info['job_id'])
-        self.assertEquals(utils.get_job_name(job), data['job_class_string'])
-        self.assertEquals(job.name, data['name'])
+        self.assertEqual(utils.get_job_name(job), data['job_class_string'])
+        self.assertEqual(job.name, data['name'])
 
         headers = {'Content-Type': 'application/json; charset=UTF-8'}
         data = {
@@ -173,7 +173,7 @@ class JobsTest(tornado.testing.AsyncHTTPTestCase):
             'minute': '*/100'}
         response = self.fetch(self.JOBS_URL + '/' + return_info['job_id'] + '?sync=true',
                               method='PUT', headers=headers, body=json.dumps(data))
-        self.assertEquals(response.code, 200)
+        self.assertEqual(response.code, 200)
         job = self.scheduler.get_job(return_info['job_id'])
-        self.assertEquals(utils.get_job_name(job), data['job_class_string'])
-        self.assertEquals(job.name, data['name'])
+        self.assertEqual(utils.get_job_name(job), data['job_class_string'])
+        self.assertEqual(job.name, data['name'])

--- a/ndscheduler/server/handlers/jobs_test.py
+++ b/ndscheduler/server/handlers/jobs_test.py
@@ -170,7 +170,7 @@ class JobsTest(tornado.testing.AsyncHTTPTestCase):
         data = {
             'job_class_string': 'hello.world!!!!',
             'name': 'hello world job~~~~',
-            'minute': '*/100'}
+            'minute': '*/20'}
         response = self.fetch(self.JOBS_URL + '/' + return_info['job_id'] + '?sync=true',
                               method='PUT', headers=headers, body=json.dumps(data))
         self.assertEqual(response.code, 200)

--- a/setup.py
+++ b/setup.py
@@ -80,12 +80,10 @@ setup(
     ],
     test_suite='nose.collector',
     install_requires=[
-        # Note ndscheduler *only* works with 3.0.x.  See the docs for more detail.
-        # https://apscheduler.readthedocs.io/en/latest/migration.html#from-v3-0-to-v3-2
         'APScheduler >= 3.0.0',
         'SQLAlchemy >= 1.0.0',
         'future >= 0.15.2',
-        'tornado >= 4.3.0',
+        'tornado < 6',
         'python-dateutil >= 2.2',
     ],
     classifiers=classifiers,

--- a/setup.py
+++ b/setup.py
@@ -75,18 +75,18 @@ setup(
     extras_require={'python_version<"3.3"': ['funcsigs']},
     tests_require=[
         'funcsigs',
-        'mock == 1.1.2',
+        'mock >= 1.1.2',
         'nose',
     ],
     test_suite='nose.collector',
     install_requires=[
         # Note ndscheduler *only* works with 3.0.x.  See the docs for more detail.
         # https://apscheduler.readthedocs.io/en/latest/migration.html#from-v3-0-to-v3-2
-        'APScheduler == 3.0.0',
-        'SQLAlchemy == 1.0.0',
-        'future == 0.15.2',
-        'tornado == 4.3.0',
-        'python-dateutil == 2.2',
+        'APScheduler >= 3.0.0',
+        'SQLAlchemy >= 1.0.0',
+        'future >= 0.15.2',
+        'tornado >= 4.3.0',
+        'python-dateutil >= 2.2',
     ],
     classifiers=classifiers,
     cmdclass={'clean': CleanHook},

--- a/simple_scheduler/requirements.txt
+++ b/simple_scheduler/requirements.txt
@@ -3,7 +3,7 @@
 # This apns library's release version still doesn't support python 3.5!
 git+git://github.com/djacobs/PyAPNs.git#egg=PyAPNs
 
-requests == 2.9.1
+requests
 
 # Uncomment this if you want to use Postgres as datastore
 #


### PR DESCRIPTION
I was looking for a good cron replacement for Debian (stretch) that could support multi-user access (or at least work from behind Apache/Nginx) and came across your guys' library, but noticed that most of the library dependencies that are already in the Debian APT repo are newer than this library's current setup. I was hoping to make Debian python packages out of your library and get them submitted to be used in Debian's main repo branch, so I forked it and made some patches to get its setup to pass during packaging and did successfully make a usable library packages out of it for python 2 and 3 separately.

I also did some testing with newer versions of the dependencies to see what were the latest it could run with without causing serious issues, since Debian will slowly use newer and newer packages with each release. I did my testing on my Win10 laptop using python 3.6.4+pipenv and a RaspberryPI 2 running Debian (stretch-armhf) using Python 2.7.13 & Python 3.5.3 to run the packaged versions. I also tested what would happen to the jobs and database (SQLite) if swapping from old to new to old again to see if there would be issues while trying to revert to an older version.

These were what I was able to conclude from my tests:

- SQLAlchemy, python-future, python-dateutil, requests and mock were all able to run fine on their latest versions.
- Tornado was able to run fine all the way up until v6. In v6 they made incompatible changes to @tornado.gen.engine and @tornado.web.asynchronous, which will have to be reworked in ndscheduler to make its API compatible.
- APscheduler was able to run fine on any version but did create backwards incompatible changes to any jobs in the database either created or modified after the upgrade. Although:
  - v3.1.0 is completely backwards compatible without changing the database.
  - v3.2.0+ apscheduler.triggers.con.CronTrigger becomes un-unpickelable from the db when reverting back because the pickling/unpickling process was changed in this version, but the jobs will fail on trying to be read or executed.
  - v3.5.0+ In apscheduler.triggers.cron.field the MonthField field was introduced into triggers, so all new and modified jobs will be unpickelable when switching back and will be deleted automatically by apscheduler when reverted back from this version.

Debian, as of this PR writing, has deb's for both apscheduler 3.3.1 and 3.5.3 in the main repo. I would recommend that anybody planning on reverting back to using an older version of apscheduler after using this fork to backup their job database, otherwise everything runs fine on the newer versions.
It is also currently using tornado 4.4.3 so that should be safe for a while before being upgraded to v6.