### PR TITLE
default_settings change to match providers

### DIFF
--- a/ndscheduler/default_settings.py
+++ b/ndscheduler/default_settings.py
@@ -67,7 +67,7 @@ DATABASE_CONFIG_DICT = {
 
 # Postgres
 #
-# DATABASE_CLASS = 'ndscheduler.corescheduler.datastore.providers.postgresql.DatastorePostgresql'
+# DATABASE_CLASS = 'ndscheduler.corescheduler.datastore.providers.postgresql.DatastorePostgres'
 # DATABASE_CONFIG_DICT = {
 #     'user': 'username',
 #     'password': '',
@@ -79,7 +79,7 @@ DATABASE_CONFIG_DICT = {
 
 # MySQL
 #
-# DATABASE_CLASS = 'ndscheduler.corescheduler.datastore.providers.mysql.DatastoreMysql'
+# DATABASE_CLASS = 'ndscheduler.corescheduler.datastore.providers.mysql.DatastoreMySQL'
 # DATABASE_CONFIG_DICT = {
 #     'user': 'username',
 #     'password': '',

--- a/ndscheduler/default_settings.py
+++ b/ndscheduler/default_settings.py
@@ -67,7 +67,7 @@ DATABASE_CONFIG_DICT = {
 
 # Postgres
 #
-# DATABASE_CLASS = 'ndscheduler.corescheduler.datastore.providers.postgresql.DatastorePostgres'
+# DATABASE_CLASS = 'ndscheduler.corescheduler.datastore.providers.postgres.DatastorePostgres'
 # DATABASE_CONFIG_DICT = {
 #     'user': 'username',
 #     'password': '',


### PR DESCRIPTION
The commented code in default_settings.py did not match the filenames/class names in corescheduler.datastore.providers