### PR TITLE
Pass correct parameters when modifying job

### DIFF
--- a/ndscheduler/corescheduler/constants.py
+++ b/ndscheduler/corescheduler/constants.py
@@ -22,6 +22,9 @@ DEFAULT_TIMEZONE = 'UTC'
 # Otherwise, if it's misfired over 1 hour, the scheduler will not rerun it.
 DEFAULT_JOB_MISFIRE_GRACE_SEC = 3600
 
+# Number of args passed to jobs
+JOB_ARGS = 5
+
 #
 # Execution status
 #

--- a/ndscheduler/corescheduler/core/base.py
+++ b/ndscheduler/corescheduler/core/base.py
@@ -14,6 +14,8 @@ class BaseScheduler (apscheduler_tornado.TornadoScheduler):
 
     # Seconds to wake up to see if it's okay to run.
     DEFAULT_WAIT_SECONDS = 60
+    # Number of args in self.run_job
+    RUN_JOB_ARGS = 5
 
     def __init__(self, datastore_class_path, *args, **kwargs):
         self.datastore_class_path = datastore_class_path
@@ -177,8 +179,7 @@ class BaseScheduler (apscheduler_tornado.TornadoScheduler):
                 # 'task_name' is not an argument for modify_job.
                 del kwargs['job_class_string']
             if 'pub_args' in kwargs:
-                # Number of args before pub_args should match those in self.run_job
-                args = args[:5] + kwargs['pub_args']
+                args = args[:self.RUN_JOB_ARGS] + kwargs['pub_args']
                 del kwargs['pub_args']
             kwargs['args'] = args
 

--- a/ndscheduler/corescheduler/core/base.py
+++ b/ndscheduler/corescheduler/core/base.py
@@ -177,7 +177,8 @@ class BaseScheduler (apscheduler_tornado.TornadoScheduler):
                 # 'task_name' is not an argument for modify_job.
                 del kwargs['job_class_string']
             if 'pub_args' in kwargs:
-                args = args[:2] + kwargs['pub_args']
+                # Number of args before pub_args should match those in self.run_job
+                args = args[:5] + kwargs['pub_args']
                 del kwargs['pub_args']
             kwargs['args'] = args
 

--- a/ndscheduler/corescheduler/core/base.py
+++ b/ndscheduler/corescheduler/core/base.py
@@ -14,8 +14,6 @@ class BaseScheduler (apscheduler_tornado.TornadoScheduler):
 
     # Seconds to wake up to see if it's okay to run.
     DEFAULT_WAIT_SECONDS = 60
-    # Number of args in self.run_job
-    RUN_JOB_ARGS = 5
 
     def __init__(self, datastore_class_path, *args, **kwargs):
         self.datastore_class_path = datastore_class_path
@@ -179,7 +177,7 @@ class BaseScheduler (apscheduler_tornado.TornadoScheduler):
                 # 'task_name' is not an argument for modify_job.
                 del kwargs['job_class_string']
             if 'pub_args' in kwargs:
-                args = args[:self.RUN_JOB_ARGS] + kwargs['pub_args']
+                args = args[:constants.JOB_ARGS] + kwargs['pub_args']
                 del kwargs['pub_args']
             kwargs['args'] = args
 

--- a/ndscheduler/corescheduler/scheduler_manager_test.py
+++ b/ndscheduler/corescheduler/scheduler_manager_test.py
@@ -94,7 +94,9 @@ class SchedulerManagerTest(tornado.testing.AsyncTestCase):
         job = self.scheduler.get_job(job_id)
         self.assertEqual(job.name, name)
 
-        arguments = [job_class_string, job_id]
+        arguments = [job_class_string, job_id,
+                     'ndscheduler.corescheduler.datastore.providers.sqlite.DatastoreSqlite',
+                     None, None]
         arguments += args
         self.assertEqual(list(job.args), arguments)
         self.assertEqual(str(job.trigger.fields[1]), month)

--- a/ndscheduler/corescheduler/utils.py
+++ b/ndscheduler/corescheduler/utils.py
@@ -9,6 +9,8 @@ import uuid
 
 import pytz
 
+from ndscheduler.corescheduler import constants
+
 
 def import_from_path(path):
     """Import a module / class from a path string.
@@ -47,7 +49,7 @@ def get_job_args(job):
     :return: task arguments
     :rtype: list of str
     """
-    return job.args[5:]
+    return job.args[constants.JOB_ARGS:]
 
 
 def get_job_kwargs(job):


### PR DESCRIPTION
Seems like a recent change caused the incorrect number of parameters to be passed to `run_job` after modifying a job. Resolves #74 
