### PR TITLE
Fix installation 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include ndscheduler/static *
+recursive-exclude simple_scheduler *

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         'future >= 0.15.2',
         'tornado < 6',
         'python-dateutil >= 2.2',
+        'requests >= 2.22.0'
     ],
     classifiers=classifiers,
     cmdclass={'clean': CleanHook},

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     download_url='http://pypi.python.org/pypi/ndscheduler#downloads',
     license='Apache License, Version 2',
     keywords='scheduler nextdoor cron python',
-    packages=find_packages(),
+    packages=find_packages(exclude=("simple_scheduler*",)),
     include_package_data=True,
     extras_require={'python_version<"3.3"': ['funcsigs']},
     tests_require=[


### PR DESCRIPTION
splitted from Pull request #80 

I've added the requests package to the setup.py-dependencies because it was missed during a fresh installation file.

Then I've excluded the Python files from the simple_scheduler example from the installation to the site-packages directory. In my opinion example files shouln't be installed to the runtime environment.