### PR TITLE
Support tornado >= 6

### DIFF
--- a/ndscheduler/server/handlers/audit_logs.py
+++ b/ndscheduler/server/handlers/audit_logs.py
@@ -36,17 +36,12 @@ class Handler(base.BaseHandler):
         """
         return self._get_logs()
 
-    @tornado.gen.engine
-    def get_logs_yield(self):
-        return_json = yield self.get_logs()
-        self.finish(return_json)
-
     @tornado.web.removeslash
-    @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get(self):
         """Returns audit logs.
 
         Handles the endpoint GET /api/v1/logs.
         """
-        self.get_logs_yield()
+        return_json = yield self.get_logs()
+        self.finish(return_json)

--- a/ndscheduler/server/handlers/executions.py
+++ b/ndscheduler/server/handlers/executions.py
@@ -42,15 +42,6 @@ class Handler(base.BaseHandler):
         """
         return self._get_execution(execution_id)
 
-    @tornado.gen.engine
-    def get_execution_yield(self, execution_id):
-        """Wrapper for get_execution to run in async mode
-
-        :param str execution_id: Execution id.
-        """
-        return_json = yield self.get_execution(execution_id)
-        self.finish(return_json)
-
     def _get_executions(self):
         """Returns a dictionary of executions in a specific time range.
 
@@ -77,15 +68,8 @@ class Handler(base.BaseHandler):
         """
         return self._get_executions()
 
-    @tornado.gen.engine
-    def get_executions_yield(self):
-        """Wrapper for get_executions to run in async mode."""
-        return_json = yield self.get_executions()
-        self.finish(return_json)
-
     @tornado.web.removeslash
-    @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get(self, execution_id=None):
         """Returns a execution or multiple executions.
 
@@ -102,9 +86,12 @@ class Handler(base.BaseHandler):
         :param str execution_id: Execution id.
         """
         if execution_id is None:
-            self.get_executions_yield()
+            # self.get_executions_yield()
+            return_json = yield self.get_executions()
         else:
-            self.get_execution_yield(execution_id)
+            # self.get_execution_yield(execution_id)
+            return_json = yield self.get_execution(execution_id)
+        self.finish(return_json)
 
     def _run_job(self, job_id):
         """Kicks off a job.
@@ -146,19 +133,8 @@ class Handler(base.BaseHandler):
         """
         return self._run_job(job_id)
 
-    @tornado.gen.engine
-    def run_job_yield(self, job_id):
-        """Wrapper for run_job to run in async mode.
-
-        :param str job_id:
-        :return:
-        """
-        return_json = yield self.run_job(job_id)
-        self.finish(return_json)
-
     @tornado.web.removeslash
-    @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def post(self, job_id):
         """Runs a job.
 
@@ -168,7 +144,8 @@ class Handler(base.BaseHandler):
         Args:
             job_id: String for job id.
         """
-        self.run_job_yield(job_id)
+        return_json = yield self.run_job(job_id)
+        self.finish(return_json)
 
     @tornado.web.removeslash
     def delete(self, job_id):

--- a/ndscheduler/server/handlers/jobs.py
+++ b/ndscheduler/server/handlers/jobs.py
@@ -58,12 +58,6 @@ class Handler(base.BaseHandler):
         """
         return self._get_jobs()
 
-    @tornado.gen.engine
-    def get_jobs_yield(self):
-        """Wrapper for get_jobs in async mode."""
-        return_json = yield self.get_jobs()
-        self.finish(return_json)
-
     def _get_job(self, job_id):
         """Returns a dictionary for a job info.
 
@@ -90,18 +84,8 @@ class Handler(base.BaseHandler):
         """
         return self._get_job(job_id)
 
-    @tornado.gen.engine
-    def get_job_yield(self, job_id):
-        """Wrapper for get_job() to run in async mode.
-
-        :param str job_id: Job id.
-        """
-        return_json = yield self.get_job(job_id)
-        self.finish(return_json)
-
     @tornado.web.removeslash
-    @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def get(self, job_id=None):
         """Returns a job or multiple jobs.
 
@@ -112,9 +96,10 @@ class Handler(base.BaseHandler):
         :param str job_id: String for job id.
         """
         if job_id is None:
-            self.get_jobs_yield()
+            return_json = yield self.get_jobs()
         else:
-            self.get_job_yield(job_id)
+            return_json = yield self.get_job(job_id)
+        self.finish(return_json)
 
     @tornado.web.removeslash
     def post(self):
@@ -160,13 +145,8 @@ class Handler(base.BaseHandler):
         """Wrapper for _delete_job() to run on a threaded executor."""
         self._delete_job(job_id)
 
-    @tornado.gen.engine
-    def delete_job_yield(self, job_id):
-        yield self.delete_job(job_id)
-
     @tornado.web.removeslash
-    @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def delete(self, job_id):
         """Deletes a job.
 
@@ -175,10 +155,9 @@ class Handler(base.BaseHandler):
 
         :param str job_id: Job id
         """
-        self.delete_job_yield(job_id)
+        yield self.delete_job(job_id)
 
-        response = {
-            'job_id': job_id}
+        response = {'job_id': job_id}
         self.set_status(200)
         self.finish(response)
 
@@ -247,17 +226,8 @@ class Handler(base.BaseHandler):
         """
         self._modify_job(job_id)
 
-    @tornado.gen.engine
-    def modify_job_yield(self, job_id):
-        """Wrapper for modify_job() to run in async mode.
-
-        :param str job_id: Job id.
-        """
-        yield self.modify_job(job_id)
-
     @tornado.web.removeslash
-    @tornado.web.asynchronous
-    @tornado.gen.engine
+    @tornado.gen.coroutine
     def put(self, job_id):
         """Modifies a job.
 
@@ -267,10 +237,9 @@ class Handler(base.BaseHandler):
         :param str job_id: Job id.
         """
         self._validate_post_data()
-        self.modify_job_yield(job_id)
+        yield self.modify_job(job_id)
 
-        response = {
-            'job_id': job_id}
+        response = {'job_id': job_id}
         self.set_status(200)
         self.finish(response)
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         'APScheduler >= 3.0.0',
         'SQLAlchemy >= 1.0.0',
         'future >= 0.15.2',
-        'tornado < 6',
+        'tornado >= 6',
         'python-dateutil >= 2.2',
     ],
     classifiers=classifiers,


### PR DESCRIPTION
In order to support newer tornado version >=6 the main change was to replace @gen.engine with @gen.coroutine (plus some small related adjustments).

The test code still needs to be adjusted for the applied changes, any help is welcome :)

* executions_test.py
* jobs_test.py