### PR TITLE
update executions in status 'running' at start-up

### DIFF
--- a/ndscheduler/corescheduler/datastore/base.py
+++ b/ndscheduler/corescheduler/datastore/base.py
@@ -180,7 +180,7 @@ class DatastoreBase(sched_sqlalchemy.SQLAlchemyJobStore):
         )
         result = self.engine.execute(sql_command)
         if result.rowcount > 0:
-            logger.warning(f"Cleaned Executions: {result.rowcount}")
+            logger.warning("Cleaned Executions: %s", result.rowcount)
         return
 
     def add_audit_log(self, job_id, job_name, event, **kwargs):


### PR DESCRIPTION
This PR fixes the issue raised in #86.
At start-up the executions in the database are searched for entries in state "scheduled", "running", or "stopping" which are assumed to be left-overs caused by previously interrupted ndscheduler.
The status of this entries is set to "failed" and the result is set to { "error": "interrupted"}. 